### PR TITLE
enh(app): Ensure client id is attached to models

### DIFF
--- a/app/Http/Controllers/API/v1/CategoryController.php
+++ b/app/Http/Controllers/API/v1/CategoryController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\API\v1;
 
 use App\Http\Controllers\API\ApiController;
 use App\Models\Category;
+use App\Rules\Iso8601Date;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -92,7 +93,7 @@ class CategoryController extends ApiController
             'type' => 'required|string|in:income,expense',
             'name' => 'required|string|max:255',
             'description' => 'nullable|string',
-            'created_at' => ['nullable', 'date_format:Y-m-d H:i:s'],
+            'created_at' => ['nullable', new Iso8601Date],
         ]);
 
         if ($validator->fails()) {

--- a/app/Http/Controllers/API/v1/GroupController.php
+++ b/app/Http/Controllers/API/v1/GroupController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\API\v1;
 
 use App\Http\Controllers\API\ApiController;
 use App\Models\Group;
+use App\Rules\Iso8601Date;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -101,7 +102,7 @@ class GroupController extends ApiController
             'client_id' => 'nullable|uuid',
             'name' => 'required|string|max:255',
             'description' => 'sometimes|string|max:255',
-            'created_at' => ['nullable', 'date_format:Y-m-d H:i:s'],
+            'created_at' => ['nullable', new Iso8601Date],
         ]);
 
         if ($validator->fails()) {

--- a/app/Http/Controllers/API/v1/PartyController.php
+++ b/app/Http/Controllers/API/v1/PartyController.php
@@ -113,12 +113,17 @@ class PartyController extends ApiController
         if ($party) {
             return $this->failure('Party already exists', 400);
         }
-        /** @var Party */
-        $party = $user->parties()->firstOrCreate($validatedData);
-        if (! empty($validatedData['client_id'])) {
-            $party->setClientGeneratedId($validatedData['client_id']);
+
+        try {
+            /** @var Party */
+            $party = $user->parties()->create($validatedData);
+            if (! empty($validatedData['client_id'])) {
+                $party->setClientGeneratedId($validatedData['client_id']);
+            }
+            $party->markAsSynced();
+        } catch (\Exception $e) {
+            return $this->failure('Failed to create party', 500, [$e->getMessage()]);
         }
-        $party->markAsSynced();
 
         return $this->success($party, 'Party created successfully', 201);
     }

--- a/app/Http/Controllers/API/v1/PartyController.php
+++ b/app/Http/Controllers/API/v1/PartyController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\API\v1;
 
 use App\Http\Controllers\API\ApiController;
 use App\Models\Party;
+use App\Rules\Iso8601Date;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use OpenApi\Attributes as OA;
@@ -104,7 +105,7 @@ class PartyController extends ApiController
             'client_id' => 'nullable|uuid',
             'name' => 'required|string|max:255',
             'description' => 'sometimes|string',
-            'created_at' => ['nullable', 'date_format:Y-m-d H:i:s'],
+            'created_at' => ['nullable', new Iso8601Date],
         ]);
 
         $user = $request->user();

--- a/app/Http/Controllers/API/v1/TransactionController.php
+++ b/app/Http/Controllers/API/v1/TransactionController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\API\v1;
 
 use App\Http\Controllers\API\ApiController;
 use App\Models\Transaction;
+use App\Rules\Iso8601Date;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use OpenApi\Attributes as OA;
@@ -104,8 +105,8 @@ class TransactionController extends ApiController
             'amount' => 'required|numeric|min:0.01',
             'type' => 'required|string|in:income,expense',
             'description' => 'nullable|string',
-            'datetime' => ['nullable', 'date_format:Y-m-d H:i:s'],
-            'created_at' => ['nullable', 'date_format:Y-m-d H:i:s'],
+            'datetime' => ['nullable', new Iso8601Date],
+            'created_at' => ['nullable', new Iso8601Date],
             'group_id' => 'nullable|integer|exists:groups,id',
             'party_id' => 'nullable|integer|exists:parties,id',
             'wallet_id' => 'nullable|integer|exists:wallets,id',
@@ -118,6 +119,14 @@ class TransactionController extends ApiController
         }
 
         $request = $validationResult['data'];
+
+        if (isset($request['datetime'])) {
+            $request['datetime'] = format_iso8601_to_sql($request['datetime']);
+        }
+
+        if (isset($request['created_at'])) {
+            $request['created_at'] = format_iso8601_to_sql($request['created_at']);
+        }
 
         $categories = [];
         if (isset($request['categories'])) {
@@ -140,7 +149,6 @@ class TransactionController extends ApiController
             }
         } catch (\Throwable $e) {
             logger()->error('Transaction creation error: '.$e->getMessage(), [
-                'request' => $request->all(),
                 'exception' => $e,
             ]);
 
@@ -271,14 +279,14 @@ class TransactionController extends ApiController
         $validationResult = $this->validateRequest($request, [
             'amount' => 'nullable|numeric|min:0.01',
             'type' => 'nullable|string|in:income,expense',
-            'datetime' => ['nullable', 'date_format:Y-m-d H:i:s'],
+            'datetime' => ['nullable', new Iso8601Date],
             'description' => 'nullable|string',
             'party_id' => 'nullable|integer|exists:parties,id',
             'wallet_id' => 'nullable|integer|exists:wallets,id',
             'group_id' => 'nullable|integer|exists:groups,id',
             'categories' => 'nullable|array',
             'categories.*' => 'integer|exists:categories,id',
-            'updated_at' => 'required|date',
+            'updated_at' => ['nullable', new Iso8601Date],
         ]);
 
         if (! $validationResult['isValidated']) {
@@ -286,6 +294,15 @@ class TransactionController extends ApiController
         }
 
         $validatedData = $validationResult['data'];
+
+        if (isset($validatedData['datetime'])) {
+            $validatedData['datetime'] = format_iso8601_to_sql($validatedData['datetime']);
+        }
+
+        if (isset($validatedData['updated_at'])) {
+            $validatedData['updated_at'] = format_iso8601_to_sql($validatedData['updated_at']);
+        }
+
         /** @var Transaction */
         $transaction = Transaction::find($id);
 

--- a/app/Http/Controllers/API/v1/TransferController.php
+++ b/app/Http/Controllers/API/v1/TransferController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\API\v1;
 
 use App\Http\Controllers\API\ApiController;
+use App\Rules\Iso8601Date;
 use App\Services\TransferService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -59,7 +60,7 @@ class TransferController extends ApiController
             'exchange_rate' => 'sometimes|numeric|min:0.01',
             'from_wallet_id' => 'required|integer|exists:wallets,id',
             'to_wallet_id' => 'required|integer|exists:wallets,id',
-            'created_at' => ['nullable', 'date_format:Y-m-d H:i:s'],
+            'created_at' => ['nullable', new Iso8601Date],
         ]);
 
         if (! $validationResult['isValidated']) {

--- a/app/Http/Controllers/API/v1/WalletController.php
+++ b/app/Http/Controllers/API/v1/WalletController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\API\v1;
 
 use App\Http\Controllers\API\ApiController;
 use App\Models\Wallet;
+use App\Rules\Iso8601Date;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use OpenApi\Attributes as OA;
@@ -106,7 +107,7 @@ class WalletController extends ApiController
             'description' => 'sometimes|string',
             'currency' => 'required|string|size:3',
             'balance' => 'sometimes|numeric|decimal:0,4',
-            'created_at' => ['nullable', 'date_format:Y-m-d H:i:s'],
+            'created_at' => ['nullable', new Iso8601Date],
         ]);
 
         $user = $request->user();

--- a/app/Rules/Iso8601Date.php
+++ b/app/Rules/Iso8601Date.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class Iso8601Date implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $pattern = '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/';
+
+        if (! is_string($value) || ! preg_match($pattern, $value)) {
+            $fail("The $attribute must be a valid ISO 8601 datetime (e.g., 2025-04-30T15:17:54.120Z).");
+        }
+    }
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,0 +1,17 @@
+<?php
+
+use Carbon\Carbon;
+
+if (! function_exists('format_iso8601_to_sql')) {
+    function format_iso8601_to_sql(?string $iso8601): ?string
+    {
+        if (! $iso8601) {
+            return null;
+        }
+        try {
+            return Carbon::parse($iso8601)->format('Y-m-d H:i:s');
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "files": [
+            "app/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/tests/Feature/CategoriesTest.php
+++ b/tests/Feature/CategoriesTest.php
@@ -33,6 +33,30 @@ class CategoriesTest extends TestCase
         $this->assertDatabaseHas('categories', ['id' => $response->json('data.id')]);
     }
 
+    public function test_api_user_can_create_expense_categories_with_client_id()
+    {
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->postJson('/api/v1/categories', [
+            'type' => 'expense',
+            'name' => 'Expense Category (with client id)',
+            'description' => 'description',
+            'client_id' => '123e4567-e89b-12d3-a456-426614174000',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    'name',
+                    'description',
+                    'user_id',
+                ],
+                'message',
+            ]);
+
+        $this->assertDatabaseHas('categories', ['id' => $response->json('data.id')]);
+    }
+
     public function test_api_user_can_get_their_categories()
     {
         $user = User::factory()->create();

--- a/tests/Feature/GroupTest.php
+++ b/tests/Feature/GroupTest.php
@@ -46,6 +46,18 @@ class GroupTest extends TestCase
         ]);
     }
 
+    public function test_api_user_can_create_groups_with_client_id()
+    {
+        $response = $this->actingAs($this->user)->postJson('/api/v1/groups', [
+            'name' => 'My Group (with client id)',
+            'description' => 'test descriptoin',
+            'client_id' => '123e4567-e89b-12d3-a456-426614174000',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('groups', ['id' => $response->json('data.id')]);
+    }
+
     public function test_api_user_can_update_their_groups()
     {
         $response = $this->createGroup();

--- a/tests/Feature/PartyTest.php
+++ b/tests/Feature/PartyTest.php
@@ -33,6 +33,17 @@ class PartyTest extends TestCase
         ]);
     }
 
+    public function test_api_user_can_create_parties_with_client_id()
+    {
+        $response = $this->actingAs($this->user)->postJson('/api/v1/parties', [
+            'name' => 'My Party (with client id)',
+            'description' => 'test descriptoin',
+            'client_id' => '123e4567-e89b-12d3-a456-426614174000',
+        ]);
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('parties', ['id' => $response->json('data.id')]);
+    }
+
     private function createParty(): TestResponse
     {
         $response = $this->actingAs($this->user)->postJson('/api/v1/parties', [

--- a/tests/Feature/TransactionsTest.php
+++ b/tests/Feature/TransactionsTest.php
@@ -38,7 +38,7 @@ class TransactionsTest extends TestCase
             'amount' => 100,
             'wallet_id' => $this->wallet->id,
             'party_id' => $this->party->id,
-            'datetime' => '2025-01-01 14:25:45',
+            'datetime' => '2025-04-30T15:17:54.120Z',
         ]);
 
         $response->assertStatus(201);
@@ -62,7 +62,7 @@ class TransactionsTest extends TestCase
             'amount' => 100,
             'wallet_id' => $this->wallet->id,
             'party_id' => $this->party->id,
-            'datetime' => '2025-01-01 14:25:45',
+            'datetime' => '2025-04-30T15:17:54.120Z',
             'client_id' => '123e4567-e89b-12d3-a456-426614174000',
         ]);
 
@@ -96,7 +96,7 @@ class TransactionsTest extends TestCase
 
         $response = $this->actingAs($this->user)->putJson('/api/v1/transactions/'.$expense['id'], [
             'amount' => 200,
-            'updated_at' => '2025-02-02 14:25:45',
+            'updated_at' => '2025-05-01T15:17:54.120Z',
         ]);
 
         $response->assertStatus(200)
@@ -118,7 +118,7 @@ class TransactionsTest extends TestCase
             'type' => 'invalid_type',
             'amount' => 100,
             'wallet_id' => 1,
-            'datetime' => '2025-01-01 14:25:45',
+            'datetime' => '2025-04-30T15:17:54.120Z',
         ]);
 
         $response->assertStatus(422)
@@ -131,7 +131,7 @@ class TransactionsTest extends TestCase
             'type' => 'expense',
             'amount' => -100,
             'wallet_id' => 1,
-            'datetime' => '2025-01-01 14:25:45',
+            'datetime' => '2025-04-30T15:17:54.120Z',
         ]);
 
         $response->assertStatus(422)
@@ -181,7 +181,7 @@ class TransactionsTest extends TestCase
             ->assertStatus(403);
 
         $this->actingAs($user2)
-            ->putJson("/api/v1/transactions/{$expense['id']}", ['amount' => 200, 'updated_at' => now()])
+            ->putJson("/api/v1/transactions/{$expense['id']}", ['amount' => 200, 'updated_at' => '2025-05-01T15:17:54.120Z'])
             ->assertStatus(403);
 
         $this->actingAs($user2)

--- a/tests/Feature/TransactionsTest.php
+++ b/tests/Feature/TransactionsTest.php
@@ -55,6 +55,21 @@ class TransactionsTest extends TestCase
         $this->assertDatabaseHas('transactions', ['id' => $income['id']]);
     }
 
+    public function test_api_user_can_create_transactions_with_client_id()
+    {
+        $response = $this->actingAs($this->user)->postJson('/api/v1/transactions', [
+            'type' => 'expense',
+            'amount' => 100,
+            'wallet_id' => $this->wallet->id,
+            'party_id' => $this->party->id,
+            'datetime' => '2025-01-01 14:25:45',
+            'client_id' => '123e4567-e89b-12d3-a456-426614174000',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('transactions', ['id' => $response->json('data.id')]);
+    }
+
     public function test_api_user_can_get_their_transactions()
     {
         $this->createTransaction('expense');

--- a/tests/Feature/WalletTest.php
+++ b/tests/Feature/WalletTest.php
@@ -29,6 +29,21 @@ class WalletTest extends TestCase
         ]);
     }
 
+    public function test_api_user_can_create_wallets_with_client_id()
+    {
+        $response = $this->actingAs($this->user)->postJson('/api/v1/wallets', [
+            'name' => 'My Wallet (with client id)',
+            'type' => 'bank',
+            'currency' => 'XAF',
+            'balance' => 0,
+            'description' => 'test descriptoin',
+            'client_id' => '123e4567-e89b-12d3-a456-426614174000',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('wallets', ['id' => $response->json('data.id')]);
+    }
+
     private function createWallet($type, $opening_balance = 0, $currency = 'XAF'): TestResponse
     {
         $response = $this->actingAs($this->user)->postJson('/api/v1/wallets', [


### PR DESCRIPTION
- Sync client_generated_id with categories, parties and wallets when provided
- Write tests to ensure that, create operations are still possible when `client_id` is provided