### PR TITLE
WIP: Ensure client_generated id's are unique per user per model

### DIFF
--- a/app/Http/Controllers/API/v1/WalletController.php
+++ b/app/Http/Controllers/API/v1/WalletController.php
@@ -120,7 +120,12 @@ class WalletController extends ApiController
             }
             $wallet->markAsSynced();
         } catch (\Exception $e) {
-            return $this->failure('Wallet already exists', 400);
+            logger()->error('Failed to create wallet', [
+                'user_id' => $user->id,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+            return $this->failure('Failed to create wallet', 400, [$e->getMessage()]);
         }
 
         return $this->success($wallet, 'Wallet created successfully', 201);

--- a/app/Traits/Syncable.php
+++ b/app/Traits/Syncable.php
@@ -12,6 +12,7 @@ trait Syncable
         static::created(function ($model) {
             $model->syncState()->create([
                 'last_synced_at' => now(),
+                'user_id' => auth()->id(),
             ]);
         });
     }

--- a/database/migrations/2025_04_08_194334_create_model_sync_states_table.php
+++ b/database/migrations/2025_04_08_194334_create_model_sync_states_table.php
@@ -17,6 +17,8 @@ return new class extends Migration
             $table->string('source')->nullable();
             $table->uuid('client_generated_id')->index()->nullable();
             $table->timestamp('last_synced_at');
+            $table->unsignedBigInteger('user_id');
+            $table->unique(['syncable_type', 'client_generated_id', 'user_id'], 'syncable_user_unique');
             $table->timestamps();
         });
     }

--- a/database/seeders/TransactionSeeder.php
+++ b/database/seeders/TransactionSeeder.php
@@ -12,6 +12,7 @@ class TransactionSeeder extends Seeder
     {
         foreach (range(1, 10) as $index) {
             $user = User::find($index);
+            auth()->login($user);
             if (! $user) {
                 continue;
             }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -19,6 +19,8 @@ class UserSeeder extends Seeder
                 'username' => "user{$index}",
             ]);
 
+            auth()->login($user);
+
             Party::factory(5)->create([
                 'user_id' => $user->id,
             ]);


### PR DESCRIPTION
Clients must ensure that their `local_ids`, `client_id` or `client_generated_ids` (as used in the backend) are unique for each model.

The backend must make sure, it is unique for each model per user.