### PR TITLE
feat: Implement wallet balance updates on transaction CRUD operations

### DIFF
--- a/app/Observers/TransactionObserver.php
+++ b/app/Observers/TransactionObserver.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Transaction;
+
+class TransactionObserver
+{
+    public function created(Transaction $transaction): void
+    {
+        $this->updateWalletBalance($transaction);
+    }
+
+    public function updated(Transaction $transaction): void
+    {
+        if ($transaction->wasChanged(['amount', 'type'])) {
+            $originalTransaction = new Transaction;
+            $originalTransaction->exists = true;
+            $originalTransaction->id = $transaction->id;
+            $originalTransaction->amount = $transaction->getOriginal('amount');
+            $originalTransaction->type = $transaction->getOriginal('type');
+            $originalTransaction->wallet_id = $transaction->getOriginal('wallet_id');
+            $originalTransaction->transfer_id = $transaction->getOriginal('transfer_id');
+            $originalTransaction->setRelation('wallet', $transaction->wallet);
+
+            $this->revertTransaction($originalTransaction);
+            $this->updateWalletBalance($transaction);
+        }
+    }
+
+    public function deleted(Transaction $transaction): void
+    {
+        $this->revertTransaction($transaction);
+    }
+
+    protected function updateWalletBalance(Transaction $transaction): void
+    {
+        if (! $transaction->wallet || ! is_null($transaction->transfer_id)) {
+            return;
+        }
+
+        $wallet = $transaction->wallet;
+        $amount = $transaction->amount;
+
+        $wallet->balance += ($transaction->type === 'expense') ? -$amount : $amount;
+        $wallet->save();
+    }
+
+    protected function revertTransaction(Transaction $transaction): void
+    {
+        if (! $transaction->wallet || ! is_null($transaction->transfer_id)) {
+            return;
+        }
+
+        $wallet = $transaction->wallet;
+        $amount = $transaction->amount;
+
+        $wallet->balance += ($transaction->type === 'expense') ? $amount : -$amount;
+        $wallet->save();
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\Transaction;
+use App\Observers\TransactionObserver;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -25,7 +27,7 @@ class EventServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Transaction::observe(TransactionObserver::class);
     }
 
     /**

--- a/tests/Feature/WalletBalanceTest.php
+++ b/tests/Feature/WalletBalanceTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Transaction;
+use App\Models\Wallet;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WalletBalanceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $user;
+
+    protected $wallet;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = \App\Models\User::factory()->create();
+        $this->wallet = Wallet::factory()->create([
+            'user_id' => $this->user->id,
+            'balance' => 1000.00,
+        ]);
+    }
+
+    public function test_wallet_balance_updates_on_transaction_creation()
+    {
+        $transaction = Transaction::factory()->create([
+            'user_id' => $this->user->id,
+            'wallet_id' => $this->wallet->id,
+            'amount' => 100.50,
+            'type' => 'expense',
+        ]);
+
+        $this->assertEquals(899.50, $this->wallet->fresh()->balance);
+
+        $transaction = Transaction::factory()->create([
+            'user_id' => $this->user->id,
+            'wallet_id' => $this->wallet->id,
+            'amount' => 50.25,
+            'type' => 'income',
+        ]);
+
+        $this->assertEquals(949.75, $this->wallet->fresh()->balance);
+    }
+
+    public function test_wallet_balance_updates_on_transaction_update()
+    {
+        $transaction = Transaction::factory()->create([
+            'user_id' => $this->user->id,
+            'wallet_id' => $this->wallet->id,
+            'amount' => 100.00,
+            'type' => 'expense',
+        ]);
+
+        $this->assertEquals(900.00, $this->wallet->fresh()->balance);
+
+        $transaction->update(['amount' => 50.00]);
+        $this->assertEquals(950.00, $this->wallet->fresh()->balance);
+
+        $transaction->update(['type' => 'income']);
+        $this->assertEquals(1050.00, $this->wallet->fresh()->balance);
+    }
+
+    public function test_wallet_balance_updates_on_transaction_deletion()
+    {
+        $transaction = Transaction::factory()->create([
+            'user_id' => $this->user->id,
+            'wallet_id' => $this->wallet->id,
+            'amount' => 100.00,
+            'type' => 'expense',
+        ]);
+
+        $this->assertEquals(900.00, $this->wallet->fresh()->balance);
+
+        $transaction->delete();
+        $this->assertEquals(1000.00, $this->wallet->fresh()->balance);
+    }
+
+    public function test_wallet_balance_handles_multiple_transactions()
+    {
+        $transactions = Transaction::factory()->count(5)->create([
+            'user_id' => $this->user->id,
+            'wallet_id' => $this->wallet->id,
+            'amount' => 10.00,
+            'type' => 'expense',
+        ]);
+
+        $this->assertEquals(950.00, $this->wallet->fresh()->balance);
+
+        $transactions->first()->update(['amount' => 20.00]);
+        $this->assertEquals(940.00, $this->wallet->fresh()->balance);
+
+        $transactions->first()->delete();
+        $this->assertEquals(960.00, $this->wallet->fresh()->balance);
+    }
+}


### PR DESCRIPTION
- Add `TransactionObserver` to handle wallet balance updates
- Create comprehensive tests for wallet balance updates
- Register observer in `EventServiceProvider`
- Ensure proper handling of updates and deletes

Resolve : https://github.com/trakli/webservice/issues/58